### PR TITLE
Add pagination validation for services and controllers

### DIFF
--- a/src/OpenLib.Api/Controllers/EmprestimosController.cs
+++ b/src/OpenLib.Api/Controllers/EmprestimosController.cs
@@ -65,6 +65,11 @@ public class EmprestimosController : ControllerBase
         [FromQuery] int pagina = 1,
         [FromQuery] int tamanho = 10)
     {
+        if (PaginationGuard.Validate(this, pagina, tamanho) is { } invalidResult)
+        {
+            return invalidResult;
+        }
+
         var emprestimos = await _emprestimoService.ListarAsync(pagina, tamanho, cancellationToken);
         return Ok(emprestimos);
     }

--- a/src/OpenLib.Api/Controllers/LivrosController.cs
+++ b/src/OpenLib.Api/Controllers/LivrosController.cs
@@ -44,6 +44,11 @@ public class LivrosController : ControllerBase
         [FromQuery] int tamanho = 10
         )
     {
+        if (PaginationGuard.Validate(this, pagina, tamanho) is { } invalidResult)
+        {
+            return invalidResult;
+        }
+
         var livros = await _livroService.ListarAsync(pagina, tamanho, cancellationToken);
         return Ok(livros);
     }

--- a/src/OpenLib.Api/Controllers/PaginationGuard.cs
+++ b/src/OpenLib.Api/Controllers/PaginationGuard.cs
@@ -1,0 +1,16 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace OpenLib.Api.Controllers;
+
+internal static class PaginationGuard
+{
+    public static IActionResult? Validate(ControllerBase controller, int pagina, int tamanho)
+    {
+        if (pagina < 1 || tamanho < 1)
+        {
+            return controller.BadRequest(new { erro = "Os parâmetros de paginação devem ser maiores ou iguais a 1." });
+        }
+
+        return null;
+    }
+}

--- a/src/OpenLib.Application/Services/Implementations/EmprestimoService.cs
+++ b/src/OpenLib.Application/Services/Implementations/EmprestimoService.cs
@@ -61,6 +61,16 @@ public class EmprestimoService : IEmprestimoService
 
     public async Task<IReadOnlyCollection<EmprestimoDto>> ListarAsync(int pagina, int tamanho, CancellationToken cancellationToken)
     {
+        if (pagina < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(pagina), "O parâmetro pagina deve ser maior ou igual a 1.");
+        }
+
+        if (tamanho < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(tamanho), "O parâmetro tamanho deve ser maior ou igual a 1.");
+        }
+
         var emprestimos = await _emprestimoRepository.ListarAsync(pagina, tamanho, cancellationToken);
         return emprestimos.Select(EmprestimoDto.FromEntity).ToList();
     }

--- a/src/OpenLib.Application/Services/Implementations/LivroService.cs
+++ b/src/OpenLib.Application/Services/Implementations/LivroService.cs
@@ -38,6 +38,16 @@ public class LivroService : ILivroService
 
     public async Task<IReadOnlyCollection<LivroDto>> ListarAsync(int pagina, int tamanho, CancellationToken cancellationToken)
     {
+        if (pagina < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(pagina), "O parâmetro pagina deve ser maior ou igual a 1.");
+        }
+
+        if (tamanho < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(tamanho), "O parâmetro tamanho deve ser maior ou igual a 1.");
+        }
+
         var livros = await _livroRepository.ListarAsync(pagina, tamanho, cancellationToken);
         return livros.Select(LivroDto.FromEntity).ToList();
     }

--- a/tests/OpenLib.UnitTests/Api/Controllers/EmprestimosControllerTests.cs
+++ b/tests/OpenLib.UnitTests/Api/Controllers/EmprestimosControllerTests.cs
@@ -1,0 +1,55 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using OpenLib.Api.Controllers;
+using OpenLib.Application.DTOs;
+using OpenLib.Application.Services;
+using Xunit;
+
+namespace OpenLib.UnitTests.Api.Controllers;
+
+public class EmprestimosControllerTests
+{
+    [Fact]
+    public async Task Listar_DeveRetornarBadRequest_QuandoPaginaForInvalida()
+    {
+        var service = new StubEmprestimoService();
+        var controller = new EmprestimosController(service);
+
+        var resultado = await controller.Listar(CancellationToken.None, 0, 10);
+
+        resultado.Result.Should().BeOfType<BadRequestObjectResult>();
+        service.ListarFoiChamado.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Listar_DeveRetornarBadRequest_QuandoTamanhoForInvalido()
+    {
+        var service = new StubEmprestimoService();
+        var controller = new EmprestimosController(service);
+
+        var resultado = await controller.Listar(CancellationToken.None, 1, 0);
+
+        resultado.Result.Should().BeOfType<BadRequestObjectResult>();
+        service.ListarFoiChamado.Should().BeFalse();
+    }
+
+    private sealed class StubEmprestimoService : IEmprestimoService
+    {
+        public bool ListarFoiChamado { get; private set; }
+
+        public Task<EmprestimoDto> SolicitarAsync(SolicitarEmprestimoRequest request, CancellationToken cancellationToken)
+            => throw new NotImplementedException();
+
+        public Task<EmprestimoDto> DevolverAsync(int id, DevolverEmprestimoRequest request, CancellationToken cancellationToken)
+            => throw new NotImplementedException();
+
+        public Task<EmprestimoDto?> ObterPorIdAsync(int id, CancellationToken cancellationToken)
+            => throw new NotImplementedException();
+
+        public Task<IReadOnlyCollection<EmprestimoDto>> ListarAsync(int pagina, int tamanho, CancellationToken cancellationToken)
+        {
+            ListarFoiChamado = true;
+            return Task.FromResult<IReadOnlyCollection<EmprestimoDto>>(Array.Empty<EmprestimoDto>());
+        }
+    }
+}

--- a/tests/OpenLib.UnitTests/Api/Controllers/LivrosControllerTests.cs
+++ b/tests/OpenLib.UnitTests/Api/Controllers/LivrosControllerTests.cs
@@ -1,0 +1,52 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using OpenLib.Api.Controllers;
+using OpenLib.Application.DTOs;
+using OpenLib.Application.Services;
+using Xunit;
+
+namespace OpenLib.UnitTests.Api.Controllers;
+
+public class LivrosControllerTests
+{
+    [Fact]
+    public async Task Listar_DeveRetornarBadRequest_QuandoPaginaForInvalida()
+    {
+        var service = new StubLivroService();
+        var controller = new LivrosController(service);
+
+        var resultado = await controller.Listar(CancellationToken.None, 0, 10);
+
+        resultado.Result.Should().BeOfType<BadRequestObjectResult>();
+        service.ListarFoiChamado.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Listar_DeveRetornarBadRequest_QuandoTamanhoForInvalido()
+    {
+        var service = new StubLivroService();
+        var controller = new LivrosController(service);
+
+        var resultado = await controller.Listar(CancellationToken.None, 1, 0);
+
+        resultado.Result.Should().BeOfType<BadRequestObjectResult>();
+        service.ListarFoiChamado.Should().BeFalse();
+    }
+
+    private sealed class StubLivroService : ILivroService
+    {
+        public bool ListarFoiChamado { get; private set; }
+
+        public Task<LivroDto> CriarAsync(CreateLivroRequest request, CancellationToken cancellationToken)
+            => throw new NotImplementedException();
+
+        public Task<LivroDto?> ObterPorIdAsync(int id, CancellationToken cancellationToken)
+            => throw new NotImplementedException();
+
+        public Task<IReadOnlyCollection<LivroDto>> ListarAsync(int pagina, int tamanho, CancellationToken cancellationToken)
+        {
+            ListarFoiChamado = true;
+            return Task.FromResult<IReadOnlyCollection<LivroDto>>(Array.Empty<LivroDto>());
+        }
+    }
+}

--- a/tests/OpenLib.UnitTests/Application/EmprestimoServiceTests.cs
+++ b/tests/OpenLib.UnitTests/Application/EmprestimoServiceTests.cs
@@ -89,6 +89,20 @@ public class EmprestimoServiceTests
         pagina2.Should().HaveCount(1);
     }
 
+    [Theory]
+    [InlineData(0, 1)]
+    [InlineData(1, 0)]
+    [InlineData(-1, 2)]
+    public async Task ListarAsync_DeveLancarExcecao_QuandoParametrosInvalidos(int pagina, int tamanho)
+    {
+        await using var context = CriarContexto();
+        var service = CriarService(context);
+
+        var acao = async () => await service.ListarAsync(pagina, tamanho, CancellationToken.None);
+
+        await acao.Should().ThrowAsync<ArgumentOutOfRangeException>();
+    }
+
     private static EmprestimoService CriarService(LibraryDbContext context)
     {
         var emprestimoRepository = new EmprestimoRepository(context);

--- a/tests/OpenLib.UnitTests/Application/LivroServiceTests.cs
+++ b/tests/OpenLib.UnitTests/Application/LivroServiceTests.cs
@@ -51,6 +51,22 @@ public class LivroServiceTests
         pagina2.Select(l => l.Titulo).Should().Contain("Livro 3");
     }
 
+    [Theory]
+    [InlineData(0, 1)]
+    [InlineData(1, 0)]
+    [InlineData(-1, 5)]
+    public async Task ListarAsync_DeveLancarExcecao_QuandoParametrosPaginacaoInvalidos(int pagina, int tamanho)
+    {
+        await using var context = CriarContexto();
+        var repository = new LivroRepository(context);
+        var unitOfWork = new UnitOfWork(context);
+        var service = new LivroService(repository, unitOfWork, NullLogger<LivroService>.Instance);
+
+        var acao = async () => await service.ListarAsync(pagina, tamanho, CancellationToken.None);
+
+        await acao.Should().ThrowAsync<ArgumentOutOfRangeException>();
+    }
+
     private static LibraryDbContext CriarContexto()
     {
         var options = new DbContextOptionsBuilder<LibraryDbContext>()

--- a/tests/OpenLib.UnitTests/OpenLib.UnitTests.csproj
+++ b/tests/OpenLib.UnitTests/OpenLib.UnitTests.csproj
@@ -22,5 +22,6 @@
     <ProjectReference Include="..\..\src\OpenLib.Domain\OpenLib.Domain.csproj" />
     <ProjectReference Include="..\..\src\OpenLib.Application\OpenLib.Application.csproj" />
     <ProjectReference Include="..\..\src\OpenLib.Infrastructure\OpenLib.Infrastructure.csproj" />
+    <ProjectReference Include="..\..\src\OpenLib.Api\OpenLib.Api.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- add a reusable pagination guard for the API controllers and short-circuit bad requests
- throw ArgumentOutOfRangeException from service pagination when inputs are invalid
- add unit tests that cover invalid pagination for services and controllers

## Testing
- `dotnet test` *(fails: `dotnet` command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1837695a88331bbe828aa37d55864